### PR TITLE
Fixed the game ending at the end of the round

### DIFF
--- a/core/src/io/github/teamfractal/RoboticonQuest.java
+++ b/core/src/io/github/teamfractal/RoboticonQuest.java
@@ -270,10 +270,8 @@ public class RoboticonQuest extends Game {
 		LandPlot[][] plots = plotManager.getLandPlots();
         for (LandPlot[] plot : plots) {
             for (LandPlot aPlot : plot) {
-                if (aPlot != null) {
-                    if (!aPlot.hasOwner()) {
-                        ended = false;
-                    }
+                if (aPlot == null) {
+					ended = false;
                 }
             }
         }


### PR DESCRIPTION
Plot objects are generated when the user claims them, therefore they
will always have an owner. The game now ends when the plots array is
full of plot objects which are implicitly owned by a player.